### PR TITLE
add write lease kv

### DIFF
--- a/store/nats/store.go
+++ b/store/nats/store.go
@@ -1,4 +1,4 @@
-//go:generate go-options -new=false -output=store_options.go -option=StoreOption -prefix=With -imports=go.uber.org/zap,time Store
+//go:generate go-options -new=false -output=store_options.go -option=StoreOption -prefix=With -imports=github.com/olpie101/fast-forward/kv,go.uber.org/zap,time Store
 
 package nats
 
@@ -77,6 +77,11 @@ func New(nc *nats.Conn, enc codec.Encoding, opts ...StoreOption) (*Store, error)
 	err = applyStoreOptions(s, options...)
 	if err != nil {
 		return nil, err
+	}
+
+	err = validateStore(s)
+	if err != nil {
+		return nil, fmt.Errorf("store init: %w", err)
 	}
 
 	return s, nil
@@ -273,6 +278,21 @@ func (s *Store) releaseLeases(ctx context.Context, keys []string) error {
 		if err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+func validateStore(s *Store) error {
+	if s.js == nil {
+		return errors.New("jetstream cannot be nil")
+	}
+
+	if s.enc == nil {
+		return errors.New("encoding cannot be nil")
+	}
+
+	if s.writeLeaseKV == nil {
+		return errors.New("write lease kv cannot be nil")
 	}
 	return nil
 }

--- a/store/nats/store_options.go
+++ b/store/nats/store_options.go
@@ -5,6 +5,7 @@ package nats
 import "fmt"
 
 import (
+	"github.com/olpie101/fast-forward/kv"
 	"go.uber.org/zap"
 	"time"
 )
@@ -119,6 +120,37 @@ func (o withPullExpiryImpl) String() string {
 
 func WithPullExpiry(o time.Duration) StoreOption {
 	return withPullExpiryImpl{
+		o: o,
+	}
+}
+
+type withWriteLeaseKVImpl struct {
+	o kv.KeyValuer[*kv.NilValue]
+}
+
+func (o withWriteLeaseKVImpl) apply(c *Store) error {
+	c.writeLeaseKV = o.o
+	return nil
+}
+
+func (o withWriteLeaseKVImpl) Equal(v withWriteLeaseKVImpl) bool {
+	switch {
+	case !cmp.Equal(o.o, v.o):
+		return false
+	}
+	return true
+}
+
+func (o withWriteLeaseKVImpl) String() string {
+	name := "WithWriteLeaseKV"
+
+	// hack to avoid go vet error about passing a function to Sprintf
+	var value interface{} = o.o
+	return fmt.Sprintf("%s: %+v", name, value)
+}
+
+func WithWriteLeaseKV(o kv.KeyValuer[*kv.NilValue]) StoreOption {
+	return withWriteLeaseKVImpl{
 		o: o,
 	}
 }


### PR DESCRIPTION
Ensure that a lease to write events is obtained before inserting. This is to ensure that different events on the same version do not write at the same time "successfully"