### PR TITLE
🔊 use correct error var when logging proj worker error

### DIFF
--- a/projection/worker.go
+++ b/projection/worker.go
@@ -71,7 +71,7 @@ func (svc *Worker) Start(ctx context.Context, opts ...projection.SubscribeOption
 			ctx,
 			errs,
 			func(e error) error {
-				logger.Errorw("projection err", "worker_name", name, "err", err)
+				logger.Errorw("projection err", "worker_name", name, "err", e)
 				return fmt.Errorf("projection error occurred (%s): %w", name, e)
 			},
 		)


### PR DESCRIPTION
use the correct error variable when logging projection errors in logger