### PR TITLE
error wrapper traverse 

### DIFF
--- a/micro/endpointer.go
+++ b/micro/endpointer.go
@@ -122,6 +122,19 @@ func (e ServiceError) Error() string {
 	return e.err.Error()
 }
 
+func (e *ServiceError) Is(target error) bool {
+	// If target is a ServiceError, compare codes and underlying errors
+	if t, ok := target.(*ServiceError); ok {
+		return e.code == t.code && errors.Is(e.err, t.err)
+	}
+	// If not, check if our wrapped error matches the target
+	return errors.Is(e.err, target)
+}
+
+func (e *ServiceError) Unwrap() error {
+	return e.err
+}
+
 func (e ServiceError) ErrorParts() (string, string, []byte, micro.Headers) {
 	return e.Error(), e.code, e.body, e.headers
 }


### PR DESCRIPTION
# Enhance ServiceError with proper error chain support

Implement proper error chain traversal and comparison for ServiceError by adding
Is() and Unwrap() methods. This enables better integration with Go's error
handling mechanisms introduced in Go 1.13.

## Changes
- Add Is() method for proper error comparison through the chain
- Add Unwrap() method for explicit error chain traversal
- Maintain backward compatibility with existing error wrapping

## Technical Details

  func (e ServiceError) Error() string {
      return e.err.Error()
  }
  
+ // Is implements error chain comparison
+ func (e *ServiceError) Is(target error) bool {
+     // If target is a ServiceError, compare codes and underlying errors
+     if t, ok := target.(*ServiceError); ok {
+         return e.code == t.code && errors.Is(e.err, t.err)
+     }
+     // If not, check if our wrapped error matches the target
+     return errors.Is(e.err, target)
+ }
+
+ // Unwrap returns the underlying error
+ func (e *ServiceError) Unwrap() error {
+     return e.err
+ }
+
  func (e ServiceError) ErrorParts() (string, string, []byte, micro.Headers) {
      return e.Error(), e.code, e.body, e.headers
  }